### PR TITLE
Removed Node v18 from CI

### DIFF
--- a/.github/workflows/lint-only.yml
+++ b/.github/workflows/lint-only.yml
@@ -7,7 +7,7 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     strategy:
       matrix:
-        node: [ 18, 20, 22 ]
+        node: [ 20, 22 ]
     env:
       FORCE_COLOR: 1
     name: Node ${{ matrix.node }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     strategy:
       matrix:
-        node: [ 18, 20, 22 ]
+        node: [ 20, 22 ]
     env:
       FORCE_COLOR: 1
     name: Node ${{ matrix.node }}


### PR DESCRIPTION
ref https://github.com/nodejs/release#release-schedule

- Node v18 is EOL as of today. We no longer need to support it.
- Today we will drop the build from CI, so we won't be aware of bugs introduced
- We will drop Node v18 from the supported versions in the engines flags sometime later, likely in our next major bump, as this is quite disruptive and abrupt for people self hosting