### PR TITLE
🐛 Only apply affects:i18n for real translation changes

### DIFF
--- a/actions/label-actions/dist/index.js
+++ b/actions/label-actions/dist/index.js
@@ -458,15 +458,67 @@ module.exports = class Helpers {
     }
 
     /**
-     * Check if PR contains changes to locale files
+     * Check if PR contains translation changes worth flagging for review.
+     *
+     * Only non-English locale files count, and only when they introduce at
+     * least one non-empty value. English source files and `context.json` hold
+     * English copy (not translations), and empty `""` lines are placeholders
+     * seeded by `pnpm translate` when new keys are added — neither gives a
+     * translation reviewer anything to act on, so they must not trip the label.
+     *
      * @param {number} pullNumber
      * @returns {Promise<boolean>}
      */
     async containsLocaleChanges(pullNumber) {
         const files = await this.getPRFiles(pullNumber);
-        return files.some(file => file.filename.includes('/locales/'));
+        return files.some((file) => {
+            const filename = file.filename || '';
+            if (!filename.includes('/locales/')) {
+                return false;
+            }
+            // English source copy and context descriptions are not translations.
+            if (isEnglishLocaleFile(filename) || isContextFile(filename)) {
+                return false;
+            }
+            // GitHub omits `patch` for very large or binary diffs — we can't
+            // inspect the contents, so fall back to labelling to stay safe.
+            if (!file.patch) {
+                return true;
+            }
+            // Otherwise only label when a real (non-empty) value is added.
+            return patchAddsNonEmptyValue(file.patch);
+        });
     }
 };
+
+// Matches the `en` locale in both nested (`.../locales/en/ghost.json`) and
+// flat (`.../locales/en.json`) layouts used across Ghost repos.
+function isEnglishLocaleFile(filename) {
+    return /\/locales\/en\//.test(filename) || /\/locales\/en\.json$/.test(filename);
+}
+
+function isContextFile(filename) {
+    return /\/locales\/context\.json$/.test(filename);
+}
+
+// A JSON entry whose value has at least one character, e.g. `  "Key": "Wert",`.
+// Empty placeholders (`"Key": ""`) deliberately do not match.
+const NON_EMPTY_VALUE_PATTERN = /:\s*"(?:[^"\\]|\\.)+"\s*,?\s*$/;
+
+// True when the unified-diff patch adds at least one line carrying a non-empty
+// JSON string value. Only added lines (`+`, excluding the `+++` file header)
+// are considered.
+function patchAddsNonEmptyValue(patch) {
+    if (!patch || typeof patch !== 'string') {
+        return false;
+    }
+    return patch.split('\n').some((line) => {
+        if (!line.startsWith('+') || line.startsWith('+++')) {
+            return false;
+        }
+        return NON_EMPTY_VALUE_PATTERN.test(line.slice(1));
+    });
+}
 
 
 /***/ }),

--- a/actions/label-actions/src/helpers.js
+++ b/actions/label-actions/src/helpers.js
@@ -338,12 +338,64 @@ module.exports = class Helpers {
     }
 
     /**
-     * Check if PR contains changes to locale files
+     * Check if PR contains translation changes worth flagging for review.
+     *
+     * Only non-English locale files count, and only when they introduce at
+     * least one non-empty value. English source files and `context.json` hold
+     * English copy (not translations), and empty `""` lines are placeholders
+     * seeded by `pnpm translate` when new keys are added — neither gives a
+     * translation reviewer anything to act on, so they must not trip the label.
+     *
      * @param {number} pullNumber
      * @returns {Promise<boolean>}
      */
     async containsLocaleChanges(pullNumber) {
         const files = await this.getPRFiles(pullNumber);
-        return files.some(file => file.filename.includes('/locales/'));
+        return files.some((file) => {
+            const filename = file.filename || '';
+            if (!filename.includes('/locales/')) {
+                return false;
+            }
+            // English source copy and context descriptions are not translations.
+            if (isEnglishLocaleFile(filename) || isContextFile(filename)) {
+                return false;
+            }
+            // GitHub omits `patch` for very large or binary diffs — we can't
+            // inspect the contents, so fall back to labelling to stay safe.
+            if (!file.patch) {
+                return true;
+            }
+            // Otherwise only label when a real (non-empty) value is added.
+            return patchAddsNonEmptyValue(file.patch);
+        });
     }
 };
+
+// Matches the `en` locale in both nested (`.../locales/en/ghost.json`) and
+// flat (`.../locales/en.json`) layouts used across Ghost repos.
+function isEnglishLocaleFile(filename) {
+    return /\/locales\/en\//.test(filename) || /\/locales\/en\.json$/.test(filename);
+}
+
+function isContextFile(filename) {
+    return /\/locales\/context\.json$/.test(filename);
+}
+
+// A JSON entry whose value has at least one character, e.g. `  "Key": "Wert",`.
+// Empty placeholders (`"Key": ""`) deliberately do not match.
+const NON_EMPTY_VALUE_PATTERN = /:\s*"(?:[^"\\]|\\.)+"\s*,?\s*$/;
+
+// True when the unified-diff patch adds at least one line carrying a non-empty
+// JSON string value. Only added lines (`+`, excluding the `+++` file header)
+// are considered.
+function patchAddsNonEmptyValue(patch) {
+    if (!patch || typeof patch !== 'string') {
+        return false;
+    }
+    return patch.split('\n').some((line) => {
+        if (!line.startsWith('+') || line.startsWith('+++')) {
+            return false;
+        }
+        return NON_EMPTY_VALUE_PATTERN.test(line.slice(1));
+    });
+}

--- a/actions/label-actions/test/helpers.test.js
+++ b/actions/label-actions/test/helpers.test.js
@@ -363,10 +363,36 @@ describe('Helpers', function () {
         sinon.assert.calledWith(mockCore.error, 'Error fetching PR files: boom');
     });
 
-    it('detects locale changes from PR files', async function () {
+    it('detects a non-English locale change that adds a real value', async function () {
         sandbox.stub(helpers, 'getPRFiles').resolves([
-            {filename: 'ghost/core/locales/en.json'},
+            {filename: 'ghost/i18n/locales/de/ghost.json', patch: '@@ -1,1 +1,2 @@\n {\n+  "New": "Neu"\n }'},
             {filename: 'package.json'}
+        ]);
+
+        (await helpers.containsLocaleChanges(50)).should.be.true();
+    });
+
+    it('ignores non-English locale changes that only add empty placeholders', async function () {
+        sandbox.stub(helpers, 'getPRFiles').resolves([
+            {filename: 'ghost/i18n/locales/de/ghost.json', patch: '@@ -1,1 +1,3 @@\n {\n+  "New one": "",\n+  "New two": ""\n }'}
+        ]);
+
+        (await helpers.containsLocaleChanges(50)).should.be.false();
+    });
+
+    it('ignores English source and context.json changes', async function () {
+        sandbox.stub(helpers, 'getPRFiles').resolves([
+            {filename: 'ghost/i18n/locales/en/ghost.json', patch: '@@ -1,1 +1,2 @@\n {\n+  "New": "New"\n }'},
+            {filename: 'ghost/i18n/locales/context.json', patch: '@@ -1,1 +1,2 @@\n {\n+  "New": "Where it appears"\n }'},
+            {filename: 'ghost/core/locales/en.json', patch: '@@ -1,1 +1,2 @@\n {\n+  "New": "New"\n }'}
+        ]);
+
+        (await helpers.containsLocaleChanges(50)).should.be.false();
+    });
+
+    it('labels a non-English locale change when the patch is unavailable', async function () {
+        sandbox.stub(helpers, 'getPRFiles').resolves([
+            {filename: 'ghost/i18n/locales/de/ghost.json'}
         ]);
 
         (await helpers.containsLocaleChanges(50)).should.be.true();


### PR DESCRIPTION
## Summary

`label-actions` tagged **any** PR touching a `/locales/` path with `affects:i18n`, using a pure filename check (`files.some(f => f.filename.includes('/locales/'))`). That caught PRs whose only locale changes are the empty `""` placeholders that `pnpm translate` seeds into every non-English locale when new source keys are added. There's nothing to translate-review on those PRs, but the label still fired — which in consuming repos (e.g. Ghost) kicks off the translation-review bot and the i18n stale automation.

## What changed

`containsLocaleChanges` now inspects the diff instead of just the path, and only returns `true` when a **non-English** locale file adds **at least one non-empty value**:

- **English source** (`.../locales/en/*`, `.../locales/en.json`) and **`context.json`** are ignored — they hold English copy, not translations. The downstream reviewer already excludes them.
- **Empty `""` additions are ignored** — a real value is required.
- **No patch available** (very large / binary diff) → falls back to labelling, to stay safe.

## Behavior change (note for reviewers)

This is a deliberate contract change for a shared action: PRs whose locale changes are English-only, `context.json`-only, or empty-placeholder-only will **no longer** be tagged `affects:i18n`. `containsLocaleChanges` is used in exactly one place — adding `affects:i18n` on PR `opened` — so nothing else in the action is affected. The label is added, never removed, so existing labels are untouched.

## Testing

- Updated/added unit tests in `actions/label-actions/test/helpers.test.js` covering: real non-English value → labelled; empty-placeholder-only → not labelled; English/`context.json` → not labelled; missing patch → labelled (safe fallback).
- `yarn test` (37 passing) + `yarn lint` clean.
- `dist/` rebuilt via `yarn build`.