### PR TITLE
Add stable All tests pass check

### DIFF
--- a/.github/workflows/repo-ci.yml
+++ b/.github/workflows/repo-ci.yml
@@ -127,3 +127,13 @@ jobs:
               throw new Error(`Slack webhook failed with ${response.status}`);
           }
           EOF
+
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [validate]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1


### PR DESCRIPTION
## Summary

- Added an `all-tests-pass` aggregator job to repo CI.
- The job is named `All tests pass` so branch protection/rulesets have one stable status check to require.
- The gate depends on the existing `validate` matrix and fails if any validation leg fails or is cancelled.

ref [GVA-817](https://linear.app/ghost/issue/GVA-817/clean-repos-actions)

## Verification

- Parsed `.github/workflows/repo-ci.yml` locally with Ruby YAML.
- `git diff --check`
- `actions/label-actions`: `yarn --prefer-offline --frozen-lockfile && yarn test && yarn build`
- `actions/slack-build`: `yarn --prefer-offline --frozen-lockfile && yarn test && yarn build`

## Handoff

This is the Clean Repos required-check gate. After this PR is green, review-thread clean, and merged to `main`, the next ordered step is repo settings/protection: verify the repository ruleset requires `All tests pass` and align repo settings with Ghost defaults.
