### PR TITLE
Normalize Renovate preset reference

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>tryghost/renovate-config"
+    "local>TryGhost/renovate-config"
   ]
 }


### PR DESCRIPTION
## Summary
- normalize the root Renovate config to extend `local>TryGhost/renovate-config`
- keep the existing `renovate.json` location and schema unchanged

ref [GVA-817](https://linear.app/ghost/issue/GVA-817/clean-repos-actions)

## Renovate decision
- Rationale: standardizing Renovate config across TryGhost repos after CI trust, the stable required check, and repo settings are in place.
- Shared preset: `local>TryGhost/renovate-config`.
- CI-trust source: repo-meta via `resolve_preset.py Actions`, which reports `ci_trust: high` and `expected_preset: default`.
- Previous config location: root `renovate.json`.
- New config location: root `renovate.json`.
- `package.json` key removal: none; no package-level Renovate config exists.
- Overrides retained or dropped: none; the existing config only extended the shared preset.
- Runtime/package-manager package rules: none added; this repo targets the GitHub Actions `node20` action runtime, CI runs on Node 22, and no exact Node patch, `packageManager`, pnpm, or dependency compatibility cap is declared.

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('renovate.json', 'utf8')); console.log('renovate.json parses')"`
- `npx --yes --package renovate renovate-config-validator renovate.json`
- `git diff --check`
