### PR TITLE
Improve Actions repository docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,6 @@
 - If you touch lint or CI behavior, also review `.github/workflows/repo-ci.yml`, `.github/workflows/test.yml`, and `.github/workflows/lint-only.yml`.
 
 ## Notes
-- `label-actions` is the only action with an automated test suite in this repository.
+- Both action packages have automated Vitest coverage.
 - The repository CI expects pnpm-based installs and commands for local action packages; reusable workflows may still use Yarn for downstream repositories.
 - Packaged action manifests currently target the GitHub Actions `node20` runtime.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,46 @@
 # Actions
 
-This repository contains all of the GitHub Actions workflows that we re-use across our repositories.
+Reusable GitHub Actions and workflow templates for Ghost repositories.
 
-# Copyright & License 
+This repo contains two packaged Node actions under `actions/*`, plus reusable
+workflows under `.github/workflows` that other Ghost repositories call from
+their own CI.
+
+## Actions
+
+- `actions/label-actions`: triages issues and pull requests by applying labels,
+  leaving standard comments, closing stale `needs:info` items, and enabling
+  auto-merge when the matching label is applied.
+- `actions/slack-build`: sends a Slack build notification for a workflow run
+  using `SLACK_WEBHOOK_URL`.
+
+Each action is a standalone pnpm package. There is no root package manager
+workspace, so run installs and checks from the action directory you are changing.
+
+```sh
+cd actions/label-actions
+pnpm install --frozen-lockfile
+pnpm lint
+pnpm test
+pnpm build
+```
+
+Use the same command sequence from `actions/slack-build` when changing that
+action.
+
+When runtime code changes, run `pnpm build` and commit the regenerated `dist/`
+output with the source change. GitHub Actions loads the packaged files declared
+in each action's `action.yml`.
+
+## Reusable workflows
+
+- `.github/workflows/test.yml`: reusable Yarn-based test workflow for downstream
+  repositories.
+- `.github/workflows/lint-only.yml`: reusable Yarn-based lint workflow for
+  downstream repositories.
+- `.github/workflows/repo-ci.yml`: this repository's own pnpm-based validation
+  for the packaged actions.
+
+## Copyright & License
 
 Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](LICENSE).

--- a/actions/label-actions/README.md
+++ b/actions/label-actions/README.md
@@ -7,7 +7,9 @@ Loosely inspired by [Label Actions](https://github.com/dessant/label-actions) by
 ## Develop
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `pnpm install` to install top-level dependencies.
+2. `cd actions/label-actions`
+3. Run `pnpm install --frozen-lockfile` to install this action's dependencies.
+4. Run `pnpm lint` and `pnpm test` before changing packaged behavior.
 
 ## Building
 


### PR DESCRIPTION
ref [GVA-817](https://linear.app/ghost/issue/GVA-817/clean-repos-actions)

## Summary
- expanded the root README with the repo purpose, packaged actions, reusable workflows, and package-local pnpm validation commands
- corrected the label-actions package README to use package-local pnpm setup and checks
- updated AGENTS.md to reflect that both action packages now have Vitest coverage
- updated the GitHub repository description to: `Reusable GitHub Actions and workflow templates for Ghost repositories`

## Clean Repos docs ledger
- README: done; root README now explains what the repo is, what each action does, and how to validate package-local changes
- AGENTS: done; stale test-suite guidance was corrected
- Supporting docs: not applicable; README and AGENTS remain concise and there is no deeper operational topic that needs a `/docs` split
- Diagrams: not applicable; the repo structure is simple enough for prose and no flow/state diagram would clarify the docs
- GitHub description: done; live repo description now matches the verified repo purpose

## Test plan
- `git diff --check HEAD~1..HEAD`

Docs-only change; package tests were not rerun.