### PR TITLE
Keep needs:info issues open after human replies

### DIFF
--- a/actions/label-actions/dist/index.js
+++ b/actions/label-actions/dist/index.js
@@ -187,8 +187,8 @@ module.exports = class Helpers {
             lastComment && // we have a comment in the timeline events
             new Date(lastComment.created_at) > new Date(labelEvent.created_at) &&
             // that comment is newer than the label
-            lastComment.actor.type === 'Bot' && // the comment was by a bot
-            !Helpers.CORE_TEAM_TRIAGERS.includes(lastComment.actor.login) // the comment was not by the Core team triagers
+            (lastComment.actor.type !== 'Bot' || // any human reply means we're waiting on internal triage
+                !Helpers.CORE_TEAM_TRIAGERS.includes(lastComment.actor.login)) // non-triager bot replies should also pause auto-close
         );
     }
 

--- a/actions/label-actions/src/helpers.js
+++ b/actions/label-actions/src/helpers.js
@@ -67,8 +67,8 @@ module.exports = class Helpers {
             lastComment && // we have a comment in the timeline events
             new Date(lastComment.created_at) > new Date(labelEvent.created_at) &&
             // that comment is newer than the label
-            lastComment.actor.type === 'Bot' && // the comment was by a bot
-            !Helpers.CORE_TEAM_TRIAGERS.includes(lastComment.actor.login) // the comment was not by the Core team triagers
+            (lastComment.actor.type !== 'Bot' || // any human reply means we're waiting on internal triage
+                !Helpers.CORE_TEAM_TRIAGERS.includes(lastComment.actor.login)) // non-triager bot replies should also pause auto-close
         );
     }
 

--- a/actions/label-actions/test/helpers.test.js
+++ b/actions/label-actions/test/helpers.test.js
@@ -94,7 +94,7 @@ describe('Helpers', function () {
         helpers.isPendingOnInternal(existingTimelineEvents, labelEvent).should.be.true();
     });
 
-    it('detects newer bot comments from non-triagers as pending on internal', function () {
+    it('detects newer comments from non-triagers as pending on internal', function () {
         const existingTimelineEvents = [
             {
                 event: 'commented',
@@ -116,7 +116,7 @@ describe('Helpers', function () {
         helpers.isPendingOnInternal(existingTimelineEvents, labelEvent).should.be.true();
     });
 
-    it('does not mark human comments as pending on internal', function () {
+    it('detects newer human comments as pending on internal', function () {
         const existingTimelineEvents = [
             {
                 event: 'commented',
@@ -135,7 +135,29 @@ describe('Helpers', function () {
             },
         };
 
-        helpers.isPendingOnInternal(existingTimelineEvents, labelEvent).should.be.false();
+        helpers.isPendingOnInternal(existingTimelineEvents, labelEvent).should.be.true();
+    });
+
+    it('detects newer core team human comments as pending on internal', function () {
+        const existingTimelineEvents = [
+            {
+                event: 'commented',
+                created_at: '2026-03-18T00:00:00.000Z',
+                actor: {
+                    login: 'ErisDS',
+                    type: 'User',
+                },
+            },
+        ];
+
+        const labelEvent = {
+            created_at: '2026-03-17T00:00:00.000Z',
+            label: {
+                name: 'needs:info',
+            },
+        };
+
+        helpers.isPendingOnInternal(existingTimelineEvents, labelEvent).should.be.true();
     });
 
     it('checks whether dates are older than the requested number of weeks', function () {


### PR DESCRIPTION
## Summary
- Treat any newer human comment after a label event as pending on internal triage
- Keep existing behavior for non-triager bot replies
- Update helper tests to cover human replies, including core-team users

## Context
A scheduled needs:info close can currently close an issue even after the reporter has replied, because only newer bot comments are treated as pending on internal. This keeps issues alive after any non-bot follow-up.

Example: TryGhost/Ghost#28222

## Testing
- pnpm test
- pnpm build