### PR TITLE
Renamed CI gate job to the org-standard "Required checks pass"

### DIFF
--- a/.github/workflows/repo-ci.yml
+++ b/.github/workflows/repo-ci.yml
@@ -128,8 +128,8 @@ jobs:
           }
           EOF
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [validate]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

Branch protection on this repo currently requires the status check named exactly "All tests pass". Requiring an individual/legacy check name couples the branch ruleset to the CI matrix and job naming: rename the job and the required check silently stops existing, blocking every PR.

The org is standardizing every repository on one stable aggregator check, `Required checks pass` (per the repo-ci-required-check convention), so rulesets have a single stable target that never has to track CI changes.

## What

- Renamed the gate job `all-tests-pass` -> `required-checks-pass` with `name: Required checks pass`.
- No behavior change: `if: always()`, `needs: [validate]` (same coverage as the old gate), and the same failure-detection step are unchanged. Top-level `permissions: contents: read` was already in place.

## Note

The branch ruleset is being updated in the same pass to require `Required checks pass` instead of "All tests pass", so this PR must go green on the new gate before merge.