### PR TITLE
Harden reusable Yarn installs

### DIFF
--- a/.github/workflows/lint-only.yml
+++ b/.github/workflows/lint-only.yml
@@ -31,5 +31,5 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: yarn
 
-      - run: yarn --prefer-offline --frozen-lockfile
+      - run: yarn --prefer-offline --frozen-lockfile --ignore-scripts
       - run: yarn lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,12 +36,7 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: yarn
 
-      - run: |
-          if [ -f lerna.json ]; then
-            yarn global add lerna@^4
-          fi
-
-      - run: yarn --prefer-offline --frozen-lockfile
+      - run: yarn --prefer-offline --frozen-lockfile --ignore-scripts
       - run: yarn test
 
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7


### PR DESCRIPTION
## What changed

- pass --ignore-scripts to frozen Yarn installs in both reusable downstream workflows
- remove the conditional yarn global add lerna@^4 step from the reusable test workflow
- retain the existing Yarn Classic cache, frozen-lockfile behavior, Node matrix, tests, lint, coverage, and notifications

## Why

These shared workflows previously allowed any direct or transitive dependency lifecycle script to execute in CI. The test workflow also installed a moving global Lerna 4 range outside the consumer lockfile.

The current public caller inventory contains two repositories:

- TryGhost/SDK calls test.yml and already pins local lerna@9.0.7
- TryGhost/eslint-plugin-ghost calls lint-only.yml

Both consumers pass after a clean scripts-disabled install. SDK's normal yarn test command resolves its local Lerna binary, so no global executable or lifecycle-script exception is required.

Tracks [PLA-317](https://linear.app/ghost/issue/PLA-317/harden-shared-yarn-installs-in-tryghostactions).

## Validation

- actionlint on test.yml, lint-only.yml, and repo-ci.yml
- TryGhost/SDK: yarn --prefer-offline --frozen-lockfile --ignore-scripts
- TryGhost/SDK: yarn test; all 17 Lerna projects passed lint and tests using local lerna@9.0.7
- TryGhost/eslint-plugin-ghost: yarn --prefer-offline --frozen-lockfile --ignore-scripts
- TryGhost/eslint-plugin-ghost: yarn lint
- git diff --check

No install-script exception was required.